### PR TITLE
Support configuring mksquashfs compressors

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ A string representing the arch. Defaults to `x86_64`.
 
 Path to the luet config to use to install the packages from
 
+### `squashfs_options.compression`
+
+Squashfs compressor. Defaults to `xz`.
+
+### `squashfs_options.compression_options`
+
+Squashfs compressor specific options. Defaults to `-Xbcj x86` if `squashfs_options.compression` is `xz`.
+
 ## Build
 
 Run `go build` or `make build` from the checkout.

--- a/pkg/burner/burner.go
+++ b/pkg/burner/burner.go
@@ -186,7 +186,7 @@ func prepareISO(s *schema.SystemSpec, fs vfs.FS, tempISO, tempOverlayfs, kernelF
 	}
 
 	info(":tv:Create squashfs")
-	if err := CreateSquashfs(filepath.Join(tempISO, "rootfs.squashfs"), "squashfs", tempOverlayfs, fs); err != nil {
+	if err := CreateSquashfs(filepath.Join(tempISO, "rootfs.squashfs"), tempOverlayfs, s.SquashfsOptions, fs); err != nil {
 		return err
 	}
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -9,18 +9,19 @@ import (
 )
 
 type SystemSpec struct {
-	Initramfs   Initramfs  `yaml:"initramfs"`
-	Label       string     `yaml:"label"`
-	Packages    Packages   `yaml:"packages"`
-	Luet        Luet       `yaml:"luet"`
-	Repository  Repository `yaml:"repository"`
-	Overlay     Overlay    `yaml:"overlay"`
-	ImagePrefix string     `yaml:"image_prefix"`
-	Date        bool       `yaml:"image_date"`
-	ImageName   string     `yaml:"image_name"`
-	Arch        string     `yaml:"arch"`
-	UEFIImage   string     `yaml:"uefi_img"`
-	RootfsImage string     `yaml:"rootfs_image"`
+	Initramfs       Initramfs       `yaml:"initramfs"`
+	Label           string          `yaml:"label"`
+	Packages        Packages        `yaml:"packages"`
+	Luet            Luet            `yaml:"luet"`
+	Repository      Repository      `yaml:"repository"`
+	Overlay         Overlay         `yaml:"overlay"`
+	ImagePrefix     string          `yaml:"image_prefix"`
+	Date            bool            `yaml:"image_date"`
+	ImageName       string          `yaml:"image_name"`
+	Arch            string          `yaml:"arch"`
+	UEFIImage       string          `yaml:"uefi_img"`
+	RootfsImage     string          `yaml:"rootfs_image"`
+	SquashfsOptions SquashfsOptions `yaml:"squashfs_options"`
 
 	BootFile     string `yaml:"boot_file"`
 	BootCatalog  string `yaml:"boot_catalog"`
@@ -90,6 +91,12 @@ type Initramfs struct {
 	RootfsFile string `yaml:"rootfs_file"`
 }
 
+type SquashfsOptions struct {
+	Compression        string `yaml:"compression"`
+	CompressionOptions string `yaml:"compression_options"`
+	Label              string `yaml:"label"`
+}
+
 func (s *SystemSpec) ISOName() (imageName string) {
 	if s.ImageName != "" {
 		imageName = s.ImageName
@@ -132,6 +139,15 @@ func setDefaults(s *SystemSpec) *SystemSpec {
 	}
 	if s.IsoHybridMBR == "" {
 		s.IsoHybridMBR = "boot/syslinux/isohdpfx.bin"
+	}
+	if s.SquashfsOptions.Label == "" {
+		s.SquashfsOptions.Label = "squashfs"
+	}
+	if s.SquashfsOptions.Compression == "" {
+		s.SquashfsOptions.Compression = "xz"
+		if s.SquashfsOptions.CompressionOptions == "" {
+			s.SquashfsOptions.CompressionOptions = "-Xbcj x86"
+		}
 	}
 	return s
 }


### PR DESCRIPTION
Using a compressor like `zstd` speeds up the building time. This might be useful for developers who need to create ISOs frequently.